### PR TITLE
feat: wire Mapbox token for Pages demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
   <script src="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.5.0/mapbox-gl-draw.js"></script>
   <script src="https://unpkg.com/@turf/turf@6/turf.min.js"></script>
   <script>
-    mapboxgl.accessToken = 'YOUR_MAPBOX_ACCESS_TOKEN';
+    mapboxgl.accessToken = 'pk.YOUR_RESTRICTED_TOKEN';
 
     const map = new mapboxgl.Map({
       container: 'map',


### PR DESCRIPTION
## Summary
- add placeholder for restricted Mapbox token in index

## Testing
- `npm test` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_68aa294e3738832ca7750767036e6190