### PR TITLE
Set Mapbox access token for demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
   <script src="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.5.0/mapbox-gl-draw.js"></script>
   <script src="https://unpkg.com/@turf/turf@6/turf.min.js"></script>
   <script>
-    mapboxgl.accessToken = 'pk.<your-restricted-token-here>';
+    mapboxgl.accessToken = 'pk.eyJ1IjoicGRoMDQwNSIsImEiOiJjbWVvcHhyeWcwYmJpMm1xdmd0bXUzdDByIn0.6thOLX7aKDCd1POUgSPdSA';
 
     const map = new mapboxgl.Map({
       container: 'map',


### PR DESCRIPTION
## Summary
- replace placeholder Mapbox token with site-restricted access token

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68aa2e0a3d94832cb5b81a943e6c2ac7