### PR TITLE
feat: add postcode finder

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,36 @@
       font-size:16px;line-height:1;transition:background .2s;
     }
     .nav-modes button.active {background:#111;color:#fff}
+
+    .pc-widget {
+      position: absolute; left: 12px; top: 12px; z-index: 1000;
+      width: 320px; padding: 10px; border-radius: 12px;
+      background: rgba(0,0,0,.55); backdrop-filter: blur(6px);
+      color: #fff; font: 13px/1.3 system-ui, sans-serif; border: 1px solid rgba(255,255,255,.12);
+    }
+    .pc-widget label { display:block; margin-bottom:4px; color:#ddd; font-size:12px; }
+    .pc-row { display:flex; gap:6px; }
+    .pc-row input{
+      flex:1; padding:8px 10px; border-radius:8px; border:1px solid rgba(255,255,255,.15);
+      background:rgba(255,255,255,.08); color:#fff; outline:none;
+    }
+    .pc-row input::placeholder{ color:rgba(255,255,255,.5); }
+    .pc-row button{
+      padding:8px 10px; border-radius:8px; border:0; font-weight:600; cursor:pointer;
+      background:#fff; color:#000;
+    }
+    .pc-row button.secondary{ background:transparent; color:#fff; border:1px solid rgba(255,255,255,.2); }
+    .pc-suggest{
+      list-style:none; margin:6px 0 0; padding:0; max-height:180px; overflow:auto;
+      border-radius:8px; border:1px solid rgba(255,255,255,.15); background:rgba(0,0,0,.7); display:none;
+    }
+    .pc-suggest[open]{ display:block; }
+    .pc-suggest li{ padding:8px 10px; cursor:pointer; }
+    .pc-suggest li:hover, .pc-suggest li[aria-selected="true"]{ background:rgba(255,255,255,.12); }
+    .pc-error{
+      margin-top:6px; padding:6px 8px; border-radius:8px; border:1px solid rgba(255,80,80,.35);
+      background:rgba(255,80,80,.1); color:#ffd9d9; font-size:12px;
+    }
   </style>
 </head>
 <body>
@@ -46,6 +76,18 @@
   <div class="toolbar" role="toolbar" aria-label="Drawing tools">
     <button id="draw-poly" class="btn" aria-pressed="true">Draw</button>
     <button id="trash" class="btn alt">Clear</button>
+  </div>
+
+  <!-- Postcode Finder (top-left HUD) -->
+  <div id="pc-widget" class="pc-widget">
+    <label for="pc-input">UK postcode</label>
+    <div class="pc-row">
+      <input id="pc-input" placeholder="e.g. SW1A 1AA" autocomplete="off" />
+      <button id="pc-find" type="button">Find</button>
+      <button id="pc-clear" type="button" class="secondary">Clear</button>
+    </div>
+    <ul id="pc-suggest" class="pc-suggest" role="listbox" aria-expanded="false"></ul>
+    <div id="pc-error" class="pc-error" hidden></div>
   </div>
 
   <div class="nav-modes" role="toolbar" aria-label="Navigation modes">
@@ -70,6 +112,7 @@
   <script src="https://unpkg.com/@turf/turf@6/turf.min.js"></script>
   <script>
     mapboxgl.accessToken = 'pk.eyJ1IjoicGRoMDQwNSIsImEiOiJjbWVvcHhyeWcwYmJpMm1xdmd0bXUzdDByIn0.6thOLX7aKDCd1POUgSPdSA';
+    window.maplibregl = mapboxgl;
 
     const sensitivity = 0.25; // lower = less sensitive
 
@@ -83,6 +126,7 @@
       maxZoom: 22,
       antialias: true
     });
+    window.map = map;
 
     map.addControl(new mapboxgl.NavigationControl({ showZoom:true, showCompass:true }), 'top-right');
 
@@ -246,6 +290,182 @@
         }
       }
     });
+  </script>
+  <script>
+/* ==== Postcode Finder (vanilla) ======================================= */
+(function () {
+  // ---- config ----------------------------------------------------------
+  // IMPORTANT: this must be your existing MapLibre map instance variable.
+  // If yours is named differently, replace `map` below.
+  const Map = window.map || window.mapInstance || window.maplibreMap || null;
+  if (!Map || typeof Map.flyTo !== "function") {
+    console.warn("[PostcodeFinder] MapLibre map not found. Make sure this script runs after you create the map.");
+    return;
+  }
+
+  const $ = (id) => document.getElementById(id);
+  const $input = $("pc-input");
+  const $find = $("pc-find");
+  const $clear = $("pc-clear");
+  const $suggest = $("pc-suggest");
+  const $error = $("pc-error");
+
+  let highlight = 0;
+  let suggestAbort = null;
+  let marker = null;
+
+  function normalise(raw) {
+    const trimmed = (raw || "").trim().toUpperCase();
+    const cleaned = trimmed.replace(/[^A-Z0-9 ]+/g, "").replace(/\s+/g, " ");
+    const pretty = cleaned;
+    const key = cleaned.replace(/\s+/g, "");
+    return { pretty, key };
+  }
+
+  async function getJSON(url, signal) {
+    const res = await fetch(url, { signal, headers: { Accept: "application/json" } });
+    if (!res.ok) throw new Error("HTTP " + res.status);
+    return res.json();
+  }
+
+  async function resolvePostcode(raw, signal) {
+    const { key } = normalise(raw);
+    if (!key) throw new Error("Enter a postcode");
+    const url = "https://api.postcodes.io/postcodes/" + encodeURIComponent(key);
+    const json = await getJSON(url, signal);
+    if (json && json.status === 200 && json.result) {
+      return {
+        postcode: json.result.postcode || key,
+        lat: json.result.latitude,
+        lng: json.result.longitude,
+        region: json.result.region,
+        country: json.result.country
+      };
+    }
+    throw new Error("Postcode not found");
+  }
+
+  async function searchSuggestions(q, signal) {
+    const key = normalise(q).key;
+    if (!key) return [];
+    const url = "https://api.postcodes.io/postcodes?q=" + encodeURIComponent(key) + "&limit=5";
+    const json = await getJSON(url, signal);
+    if (json && json.status === 200 && Array.isArray(json.result)) {
+      return json.result.map((r) => ({
+        postcode: r.postcode,
+        region: r.region,
+        country: r.country,
+        lat: r.latitude,
+        lng: r.longitude
+      }));
+    }
+    return [];
+  }
+
+  function showError(msg) {
+    $error.textContent = msg;
+    $error.hidden = !msg;
+  }
+
+  function clearSuggest() {
+    $suggest.innerHTML = "";
+    $suggest.removeAttribute("open");
+    $suggest.setAttribute("aria-expanded", "false");
+    highlight = 0;
+  }
+
+  function renderSuggest(items) {
+    clearSuggest();
+    if (!items.length) return;
+    $suggest.setAttribute("open", "");
+    $suggest.setAttribute("aria-expanded", "true");
+    items.forEach((s, i) => {
+      const li = document.createElement("li");
+      li.setAttribute("role", "option");
+      li.textContent = s.postcode + (s.region ? " — " + s.region : "");
+      if (i === 0) li.setAttribute("aria-selected", "true");
+      li.addEventListener("mousedown", (e) => {
+        e.preventDefault();
+        go(s.postcode);
+      });
+      li.addEventListener("mouseenter", () => selectIndex(i));
+      $suggest.appendChild(li);
+    });
+  }
+
+  function selectIndex(i) {
+    highlight = Math.max(0, Math.min($suggest.children.length - 1, i));
+    [...$suggest.children].forEach((el, idx) =>
+      el.setAttribute("aria-selected", idx === highlight ? "true" : "false")
+    );
+  }
+
+  function placeMarker(lng, lat) {
+    if (!marker) {
+      const el = document.createElement("div");
+      el.style.width = "14px"; el.style.height = "14px"; el.style.borderRadius = "9999px";
+      el.style.background = "#4ade80";
+      el.style.boxShadow = "0 0 0 2px #fff, 0 0 0 4px rgba(0,0,0,.35)";
+      marker = new maplibregl.Marker({ element: el }).setLngLat([lng, lat]).addTo(Map);
+    } else {
+      marker.setLngLat([lng, lat]);
+    }
+  }
+
+  function flyTo(lng, lat) {
+    Map.flyTo({ center: [lng, lat], zoom: 18, speed: 1.2 });
+  }
+
+  async function go(postcode) {
+    const raw = postcode ?? $input.value;
+    showError("");
+    try {
+      const ac = new AbortController();
+      const rec = await resolvePostcode(raw, ac.signal);
+      placeMarker(rec.lng, rec.lat);
+      flyTo(rec.lng, rec.lat);
+      clearSuggest();
+    } catch (e) {
+      const msg = /404/.test(String(e)) || /not found/i.test(String(e)) ? "Postcode not found" : "Network error";
+      showError(msg);
+    }
+  }
+
+  // events
+  $input.addEventListener("input", () => {
+    showError("");
+    const q = $input.value.trim();
+    if (suggestAbort) suggestAbort.abort();
+    if (!q) return clearSuggest();
+    suggestAbort = new AbortController();
+    const signal = suggestAbort.signal;
+    // debounce 300ms
+    clearTimeout($input._pcTimer);
+    $input._pcTimer = setTimeout(async () => {
+      try {
+        const items = await searchSuggestions(q, signal);
+        renderSuggest(items);
+      } catch (_) {}
+    }, 300);
+  });
+
+  $input.addEventListener("keydown", (e) => {
+    if ($suggest.hasAttribute("open")) {
+      if (e.key === "ArrowDown") { e.preventDefault(); selectIndex(highlight + 1); }
+      else if (e.key === "ArrowUp") { e.preventDefault(); selectIndex(highlight - 1); }
+      else if (e.key === "Enter")  { e.preventDefault(); go(($suggest.children[highlight]||{}).textContent?.split(" — ")[0]); }
+      else if (e.key === "Escape") { clearSuggest(); }
+    } else if (e.key === "Enter") {
+      e.preventDefault(); go();
+    }
+  });
+
+  $find.addEventListener("click", () => go());
+  $clear.addEventListener("click", () => { $input.value = ""; clearSuggest(); showError(""); });
+
+  // optional: auto-focus for quick testing
+  // $input.focus();
+})();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a postcode search widget with suggestions and error messages
- expose the map instance globally and alias Mapbox GL to MapLibre for widget support
- integrate vanilla JS postcode finder to resolve locations and fly/mark on the map

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4e5291e4832cb78a0f9a3267328f