### PR TITLE
Add basic coverage and time estimation helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,10 @@ See [`src/DroneRoofEstimatorHUD.tsx`](src/DroneRoofEstimatorHUD.tsx) for a minim
 React + MapLibre + TerraDraw implementation with a bottom telemetry strip and a
 right-side estimate drawer. Install dependencies then drop the component into
 your app and plug in your own pricing logic.
+
+## Coverage and time estimates
+
+[`src/coverage.ts`](src/coverage.ts) contains small helpers for computing the
+footprint of a camera at altitude and deriving survey lane spacing, trigger
+distance and mission time for rectangular areas. These functions can be imported
+into your own planner or estimator modules.

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -1,0 +1,83 @@
+export type Camera = {
+  sensorWidthMm: number;
+  sensorHeightMm: number;
+  imageWidthPx: number;
+  imageHeightPx: number;
+  focalMm: number; // physical focal length
+  trigLatencySec?: number;
+};
+
+export type PlanInputs = {
+  altitudeM: number;
+  frontOverlap: number; // 0.7 = 70%
+  sideOverlap: number;
+  gsMps: number; // ground speed m/s
+  turnTimeSec: number; // per 180° turn
+  climbRate: number;
+  descendRate: number;
+};
+
+export type CoverageResult = {
+  fx: number; // footprint width (m)
+  fy: number; // footprint height (m)
+  gsdX: number; // ground sample distance along width (m/px)
+  gsdY: number; // ground sample distance along height (m/px)
+  laneSpacing: number; // spacing between survey lanes (m)
+  triggerDist: number; // distance between exposures along-track (m)
+  exposureGap: number; // time between exposures (s)
+};
+
+/**
+ * Compute basic coverage/trigger spacing for a camera at a given altitude.
+ * Returns the footprint dimensions, lane spacing, trigger distance and GSD.
+ */
+export function coverageFrom(camera: Camera, p: PlanInputs): CoverageResult {
+  const { sensorWidthMm, sensorHeightMm, focalMm, imageWidthPx, imageHeightPx } = camera;
+  const fx = (p.altitudeM * sensorWidthMm) / focalMm; // meters
+  const fy = (p.altitudeM * sensorHeightMm) / focalMm; // meters
+  const gsdX = fx / imageWidthPx; // meters per pixel (width)
+  const gsdY = fy / imageHeightPx; // meters per pixel (height)
+
+  const laneSpacing = fy * (1 - p.sideOverlap); // meters between strips
+  const triggerDist = fx * (1 - p.frontOverlap); // along-track photo spacing
+
+  const photoRate = p.gsMps / Math.max(0.1, triggerDist); // photos/s
+  const exposureGap = 1 / photoRate + (camera.trigLatencySec || 0);
+
+  return { fx, fy, gsdX, gsdY, laneSpacing, triggerDist, exposureGap };
+}
+
+export type TimeEstimate = {
+  lanes: number;
+  laneLen: number;
+  photoCount: number;
+  surveyTimeSec: number;
+  approxMissionTimeSec: number;
+};
+
+/**
+ * Quick time estimate for a rectangular area of interest.
+ * Lm and Wm are the length and width of the rectangle in meters.
+ */
+export function timeEstimateRect(
+  Lm: number,
+  Wm: number,
+  cam: Camera,
+  plan: PlanInputs
+): TimeEstimate {
+  const { laneSpacing, triggerDist } = coverageFrom(cam, plan);
+  const lanes = Math.ceil(Wm / laneSpacing);
+  const laneLen = Lm;
+  const surveyDist = lanes * laneLen;
+  const travelTime = surveyDist / plan.gsMps + (lanes - 1) * plan.turnTimeSec;
+  const photoCount = Math.ceil(laneLen / triggerDist) * lanes;
+
+  return {
+    lanes,
+    laneLen,
+    photoCount,
+    surveyTimeSec: travelTime,
+    approxMissionTimeSec:
+      travelTime + plan.altitudeM / plan.climbRate + plan.altitudeM / plan.descendRate,
+  };
+}


### PR DESCRIPTION
## Summary
- add `coverage.ts` with reusable functions for camera footprint and mission timing
- document coverage helpers in README

## Testing
- `npx tsc --noEmit src/coverage.ts && echo "tsc success"`


------
https://chatgpt.com/codex/tasks/task_e_68aa50d0cb60832cba0f7f928e8aa7de